### PR TITLE
Add some tests for Bitset.

### DIFF
--- a/bonsai-core/src/main/scala/com/stripe/bonsai/Bitset.scala
+++ b/bonsai-core/src/main/scala/com/stripe/bonsai/Bitset.scala
@@ -66,6 +66,9 @@ object Bitset {
 
   val empty: Bitset = new Bitset(new Array[Int](0), 0, 0, 0)
 
+  def fromSeq(xs: Seq[Int]): Bitset =
+    fromBitSet(BitSet(xs: _*))
+
   def fromBitSet(bitSet: BitSet): Bitset = {
     if (bitSet.isEmpty) {
       empty

--- a/bonsai-core/src/test/scala/com/stripe/bonsai/BitsetSpec.scala
+++ b/bonsai-core/src/test/scala/com/stripe/bonsai/BitsetSpec.scala
@@ -1,0 +1,51 @@
+package com.stripe.bonsai
+
+import org.scalatest.{ WordSpec, Matchers }
+import org.scalatest.prop.Checkers
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
+import org.scalacheck.Arbitrary._
+
+import scala.collection.immutable.BitSet
+
+class BitsetSpec extends WordSpec with Matchers with Checkers {
+
+  implicit val arbitraryBitSet: Arbitrary[BitSet] =
+    Arbitrary(arbitrary[Set[Short]].map(xs => BitSet(xs.map(_ & 0xffff).toSeq: _*)))
+
+  case class BitSetWithIndex(bs: BitSet, i: Int)
+
+  implicit val arbitraryBitSetWithIndex: Arbitrary[BitSetWithIndex] =
+    Arbitrary(for {
+      len <- arbitrary[Short].map(_.toInt)
+      vals <- Gen.listOfN(len, arbitrary[Boolean])
+      i <- Gen.choose(0, len)
+      bs = BitSet(vals.zipWithIndex.filter(_._1).map(_._2): _*)
+    } yield BitSetWithIndex(bs, i))
+
+  "Bitset" should {
+    "be equivalent to Set[Int]" in {
+      check { (xs: BitSet) =>
+        val bs = Bitset.fromBitSet(xs)
+        xs.isEmpty || (0 to xs.max).forall { x => bs(x) == xs(x) }
+      }
+    }
+
+    "be isomorphic to BitSet" in {
+      check { (xs: BitSet) =>
+        val bs = Bitset.fromBitSet(xs)
+        xs == bs.toBitSet
+      }
+    }
+
+    "rank(i) is equal to number of 1 bits below i" in {
+      check { (bswi: BitSetWithIndex) =>
+        val BitSetWithIndex(xs, i) = bswi
+        val bs = Bitset.fromBitSet(xs)
+        if (xs.isEmpty) true
+        else bs.rank(i) == xs.filter(_ <= i).size
+      }
+    }
+  }
+}


### PR DESCRIPTION
This commit adds some basic testing of the membership method (.apply)
as well as the .rank method. These tests cover the majority of Bitset's
useful functionality.

It would be good to measure our coverage and see if there are intersting
cases we are still missing.

Review by @tixxit
