### PR TITLE
Full binary trees

### DIFF
--- a/bonsai-core/src/main/scala/com/stripe/bonsai/FullBinaryTree.scala
+++ b/bonsai-core/src/main/scala/com/stripe/bonsai/FullBinaryTree.scala
@@ -9,7 +9,7 @@ import com.stripe.bonsai.layout.Vec
 class FullBinaryTree[A, B](
   val bitset: Bitset,
   val leaf: Bitset,
-  val nodeLabels: Vec[A],
+  val branchLabels: Vec[A],
   val leafLabels: Vec[B]
 ) { tree =>
   private def mkNodeRef(bitsetIndex: Int): NodeRef =
@@ -26,7 +26,7 @@ class FullBinaryTree[A, B](
     def leftChild: NodeRef = tree.mkNodeRef(2 * index + 1)
     def rightChild: NodeRef = tree.mkNodeRef(2 * index + 2)
     def isLeaf: Boolean = tree.leaf(index)
-    def nodeLabel: A = nodeLabels(index - bitset.rank(index))
+    def branchLabel: A = branchLabels(index - bitset.rank(index))
     def leafLabel: B = leafLabels(bitset.rank(index) - 1)
   }
 }
@@ -35,12 +35,12 @@ object FullBinaryTree {
   implicit def BonsaiFullBinaryTreeOps[A, B]: FullBinaryTreeOps[FullBinaryTree[A, B]] =
     new FullBinaryTreeOps[FullBinaryTree[A, B]] {
       type Node = FullBinaryTree[A, B]#NodeRef
-      type NodeLabel = A
+      type BranchLabel = A
       type LeafLabel = B
 
       def root(t: FullBinaryTree[A, B]): Option[Node] = t.root
       def isLeaf(node: Node): Boolean = node.isLeaf
-      def nodeLabel(node: Node): NodeLabel = node.nodeLabel
+      def branchLabel(node: Node): BranchLabel = node.branchLabel
       def leafLabel(node: Node): LeafLabel = node.leafLabel
       def leftChild(node: Node): Node = node.leftChild
       def rightChild(node: Node): Node = node.rightChild
@@ -59,13 +59,13 @@ object FullBinaryTree {
    *
    * @param tree the tree whose structure we are copying
    */
-  def apply[T](tree: T)(implicit ev: FullBinaryTreeOps.WithLayout[T]): FullBinaryTree[ev.treeOps.NodeLabel, ev.treeOps.LeafLabel] = {
+  def apply[T](tree: T)(implicit ev: FullBinaryTreeOps.WithLayout[T]): FullBinaryTree[ev.treeOps.BranchLabel, ev.treeOps.LeafLabel] = {
     import ev._
     import treeOps._
 
     val bitsBldr = Bitset.newBuilder
     val leafBldr = Bitset.newBuilder
-    val nodeLabelBldr = Layout[NodeLabel].newBuilder
+    val branchLabelBldr = Layout[BranchLabel].newBuilder
     val leafLabelBldr = Layout[LeafLabel].newBuilder
 
     def build(nodes: Queue[Option[Node]]): Unit =
@@ -82,7 +82,7 @@ object FullBinaryTree {
               build(rest.enqueue(None).enqueue(None))
             } else {
               leafBldr += false
-              nodeLabelBldr += treeOps.nodeLabel(node)
+              branchLabelBldr += treeOps.branchLabel(node)
               build(rest.enqueue(Some(treeOps.leftChild(node))).enqueue(Some(treeOps.rightChild(node))))
             }
         }
@@ -92,7 +92,7 @@ object FullBinaryTree {
       case Some(node) =>
         build(Queue(Some(node)))
         new FullBinaryTree(bitsBldr.result(), leafBldr.result(),
-          nodeLabelBldr.result(), leafLabelBldr.result())
+          branchLabelBldr.result(), leafLabelBldr.result())
 
       case None =>
         FullBinaryTree.empty

--- a/bonsai-core/src/main/scala/com/stripe/bonsai/FullBinaryTree.scala
+++ b/bonsai-core/src/main/scala/com/stripe/bonsai/FullBinaryTree.scala
@@ -1,0 +1,101 @@
+package com.stripe.bonsai
+
+import scala.language.existentials
+
+import scala.collection.immutable.Queue
+
+import com.stripe.bonsai.layout.Vec
+
+class FullBinaryTree[A, B](
+  val bitset: Bitset,
+  val leaf: Bitset,
+  val nodeLabels: Vec[A],
+  val leafLabels: Vec[B]
+) { tree =>
+  private def mkNodeRef(bitsetIndex: Int): NodeRef =
+    new NodeRef(bitset.rank(bitsetIndex) - 1)
+
+  def root: Option[NodeRef] =
+    if (bitset(0)) Some(mkNodeRef(0))
+    else None
+
+  def isEmpty: Boolean =
+    root.isEmpty
+
+  final class NodeRef private[FullBinaryTree] (index: Int) {
+    def leftChild: NodeRef = tree.mkNodeRef(2 * index + 1)
+    def rightChild: NodeRef = tree.mkNodeRef(2 * index + 2)
+    def isLeaf: Boolean = tree.leaf(index)
+    def nodeLabel: A = nodeLabels(index - bitset.rank(index))
+    def leafLabel: B = leafLabels(bitset.rank(index) - 1)
+  }
+}
+
+object FullBinaryTree {
+  implicit def BonsaiFullBinaryTreeOps[A, B]: FullBinaryTreeOps[FullBinaryTree[A, B]] =
+    new FullBinaryTreeOps[FullBinaryTree[A, B]] {
+      type Node = FullBinaryTree[A, B]#NodeRef
+      type NodeLabel = A
+      type LeafLabel = B
+
+      def root(t: FullBinaryTree[A, B]): Option[Node] = t.root
+      def isLeaf(node: Node): Boolean = node.isLeaf
+      def nodeLabel(node: Node): NodeLabel = node.nodeLabel
+      def leafLabel(node: Node): LeafLabel = node.leafLabel
+      def leftChild(node: Node): Node = node.leftChild
+      def rightChild(node: Node): Node = node.rightChild
+    }
+
+  /**
+   * Returns an empty, 0-node bonsai `Tree`.
+   */
+  def empty[A: Layout, B: Layout]: FullBinaryTree[A, B] =
+    new FullBinaryTree(Bitset.empty, Bitset.empty, Layout[A].empty, Layout[B].empty)
+
+  /**
+   * Constructs a bonsai `Tree` from some other arbitrary tree structure. The 2
+   * trees will be structurally equivalent, though the bonsai tree will (likely)
+   * require much less space.
+   *
+   * @param tree the tree whose structure we are copying
+   */
+  def apply[T](tree: T)(implicit ev: FullBinaryTreeOps.WithLayout[T]): FullBinaryTree[ev.treeOps.NodeLabel, ev.treeOps.LeafLabel] = {
+    import ev._
+    import treeOps._
+
+    val bitsBldr = Bitset.newBuilder
+    val leafBldr = Bitset.newBuilder
+    val nodeLabelBldr = Layout[NodeLabel].newBuilder
+    val leafLabelBldr = Layout[LeafLabel].newBuilder
+
+    def build(nodes: Queue[Option[Node]]): Unit =
+      if (nodes.nonEmpty) {
+        nodes.dequeue match {
+          case (None, rest) =>
+            bitsBldr += false
+            build(rest)
+          case (Some(node), rest) =>
+            bitsBldr += true
+            if (treeOps.isLeaf(node)) {
+              leafBldr += true
+              leafLabelBldr += treeOps.leafLabel(node)
+              build(rest.enqueue(None).enqueue(None))
+            } else {
+              leafBldr += false
+              nodeLabelBldr += treeOps.nodeLabel(node)
+              build(rest.enqueue(Some(treeOps.leftChild(node))).enqueue(Some(treeOps.rightChild(node))))
+            }
+        }
+      }
+
+    tree.root match {
+      case Some(node) =>
+        build(Queue(Some(node)))
+        new FullBinaryTree(bitsBldr.result(), leafBldr.result(),
+          nodeLabelBldr.result(), leafLabelBldr.result())
+
+      case None =>
+        FullBinaryTree.empty
+    }
+  }
+}

--- a/bonsai-core/src/main/scala/com/stripe/bonsai/FullBinaryTreeOps.scala
+++ b/bonsai-core/src/main/scala/com/stripe/bonsai/FullBinaryTreeOps.scala
@@ -2,13 +2,14 @@ package com.stripe.bonsai
 
 trait FullBinaryTreeOps[T] extends TreeOps[T] {
   type LeafLabel
-  type NodeLabel
-  type Label = Either[NodeLabel, LeafLabel]
+  type BranchLabel
+  type Label = Either[BranchLabel, LeafLabel]
 
   def isLeaf(node: Node): Boolean
 
-  // This is terribly named, since Node/node here mean different things.
-  def nodeLabel(node: Node): NodeLabel
+  def isBranch(node: Node): Boolean = !isLeaf(node)
+
+  def branchLabel(node: Node): BranchLabel
 
   def leafLabel(node: Node): LeafLabel
 
@@ -18,23 +19,21 @@ trait FullBinaryTreeOps[T] extends TreeOps[T] {
 
   def rightChild(node: Node): Node
 
-  def label(node: Node): Either[NodeLabel, LeafLabel] =
-    if (isLeaf(node)) Right(leafLabel(node))
-    else Left(nodeLabel(node))
+  def label(node: Node): Either[BranchLabel, LeafLabel] =
+    if (isLeaf(node)) Right(leafLabel(node)) else Left(branchLabel(node))
 
   // We could implement everything in terms of this instead, but I suspect
   // we'd just end up constantly overriding this for perf :\
-  def foldLabel[A](node: Node)(f: NodeLabel => A, g: LeafLabel => A): A =
-    if (isLeaf(node)) g(leafLabel(node))
-    else f(nodeLabel(node))
+  def foldLabel[A](node: Node)(f: BranchLabel => A, g: LeafLabel => A): A =
+    if (isLeaf(node)) g(leafLabel(node)) else f(branchLabel(node))
 
   def children(node: Node): Iterable[Node] =
-    if (isLeaf(node)) Iterable.empty
-    else Iterable(leftChild(node), rightChild(node))
+    if (isLeaf(node)) Nil else leftChild(node) :: rightChild(node) :: Nil
 }
 
 object FullBinaryTreeOps {
-  final def apply[T](implicit ops: FullBinaryTreeOps[T]) = ops
+
+  final def apply[T](implicit ops: FullBinaryTreeOps[T]): FullBinaryTreeOps[T] = ops
 
   /**
    * A type alias for `TreeOps` that let's you use the `Node` and `Label` types
@@ -42,13 +41,13 @@ object FullBinaryTreeOps {
    * this, but is invaluable when you do.
    */
   type Aux[T, A, B] = FullBinaryTreeOps[T] {
-    type NodeLabel = A
+    type BranchLabel = A
     type LeafLabel = B
   }
 
   trait WithLayout[T] {
     implicit val treeOps: FullBinaryTreeOps[T]
-    implicit val nodeLayout: Layout[treeOps.NodeLabel]
+    implicit val branchLayout: Layout[treeOps.BranchLabel]
     implicit val leafLayout: Layout[treeOps.LeafLabel]
   }
 
@@ -56,7 +55,7 @@ object FullBinaryTreeOps {
     implicit def mkWithLayout[T, A, B](implicit ops: Aux[T, A, B], la: Layout[A], lb: Layout[B]): WithLayout[T] =
       new WithLayout[T] {
         val treeOps = ops
-        val nodeLayout = la
+        val branchLayout = la
         val leafLayout = lb
       }
   }

--- a/bonsai-core/src/main/scala/com/stripe/bonsai/FullBinaryTreeOps.scala
+++ b/bonsai-core/src/main/scala/com/stripe/bonsai/FullBinaryTreeOps.scala
@@ -1,0 +1,63 @@
+package com.stripe.bonsai
+
+trait FullBinaryTreeOps[T] extends TreeOps[T] {
+  type LeafLabel
+  type NodeLabel
+  type Label = Either[NodeLabel, LeafLabel]
+
+  def isLeaf(node: Node): Boolean
+
+  // This is terribly named, since Node/node here mean different things.
+  def nodeLabel(node: Node): NodeLabel
+
+  def leafLabel(node: Node): LeafLabel
+
+  // These 2 assume node is not a leaf
+
+  def leftChild(node: Node): Node
+
+  def rightChild(node: Node): Node
+
+  def label(node: Node): Either[NodeLabel, LeafLabel] =
+    if (isLeaf(node)) Right(leafLabel(node))
+    else Left(nodeLabel(node))
+
+  // We could implement everything in terms of this instead, but I suspect
+  // we'd just end up constantly overriding this for perf :\
+  def foldLabel[A](node: Node)(f: NodeLabel => A, g: LeafLabel => A): A =
+    if (isLeaf(node)) g(leafLabel(node))
+    else f(nodeLabel(node))
+
+  def children(node: Node): Iterable[Node] =
+    if (isLeaf(node)) Iterable.empty
+    else Iterable(leftChild(node), rightChild(node))
+}
+
+object FullBinaryTreeOps {
+  final def apply[T](implicit ops: FullBinaryTreeOps[T]) = ops
+
+  /**
+   * A type alias for `TreeOps` that let's you use the `Node` and `Label` types
+   * with Scala's type inference / implicit lookup. You normally shouldn't need
+   * this, but is invaluable when you do.
+   */
+  type Aux[T, A, B] = FullBinaryTreeOps[T] {
+    type NodeLabel = A
+    type LeafLabel = B
+  }
+
+  trait WithLayout[T] {
+    implicit val treeOps: FullBinaryTreeOps[T]
+    implicit val nodeLayout: Layout[treeOps.NodeLabel]
+    implicit val leafLayout: Layout[treeOps.LeafLabel]
+  }
+
+  object WithLayout {
+    implicit def mkWithLayout[T, A, B](implicit ops: Aux[T, A, B], la: Layout[A], lb: Layout[B]): WithLayout[T] =
+      new WithLayout[T] {
+        val treeOps = ops
+        val nodeLayout = la
+        val leafLayout = lb
+      }
+  }
+}

--- a/bonsai-core/src/main/scala/com/stripe/bonsai/Tree.scala
+++ b/bonsai-core/src/main/scala/com/stripe/bonsai/Tree.scala
@@ -2,10 +2,7 @@ package com.stripe.bonsai
 
 import scala.language.existentials
 
-import scala.reflect.ClassTag
-
 import scala.collection.immutable.Queue
-import scala.collection.mutable.ArrayBuilder
 
 import com.stripe.bonsai.layout.Vec
 

--- a/bonsai-core/src/main/scala/com/stripe/bonsai/TreeOps.scala
+++ b/bonsai-core/src/main/scala/com/stripe/bonsai/TreeOps.scala
@@ -1,7 +1,5 @@
 package com.stripe.bonsai
 
-import scala.reflect.ClassTag
-
 /**
  * TreeOps is a type class for abstracting over arbitrary trees, allowing
  * traversal and data access. In general, it assumes that we can quickly access


### PR DESCRIPTION
This adds support for a specialization of `TreeOps` that focuses on *full binary trees*, along with a compact implementation. These are trees that have 0 or 2 children. Because of this hard distinction between # of child nodes, `FullBinaryTree`s have 2 type parameters - one for the "branch" labels and another for the "leaf" labels.