### PR TITLE
Expose more explicit tree structure in Ops.

### DIFF
--- a/bonsai-core/src/main/scala/com/stripe/bonsai/FullBinaryTree.scala
+++ b/bonsai-core/src/main/scala/com/stripe/bonsai/FullBinaryTree.scala
@@ -64,13 +64,13 @@ object FullBinaryTree {
    *
    * @param tree the tree whose structure we are copying
    */
-  def apply[T, B, L](tree: T)(implicit ev: FullBinaryTreeOps[T, B, L]): FullBinaryTree[B, L] = {
+  def apply[T, B, L](tree: T)(implicit ev: FullBinaryTreeOps[T, B, L], lb: Layout[B], ll: Layout[L]): FullBinaryTree[B, L] = {
     import ev._
 
     val bitsBldr = Bitset.newBuilder
     val leafBldr = Bitset.newBuilder
-    val branchLabelBldr = Layout[B].newBuilder
-    val leafLabelBldr = Layout[L].newBuilder
+    val branchLabelBldr = lb.newBuilder
+    val leafLabelBldr = ll.newBuilder
 
     def build(nodes: Queue[Option[Node]]): Unit =
       if (nodes.nonEmpty) {

--- a/bonsai-core/src/main/scala/com/stripe/bonsai/FullBinaryTree.scala
+++ b/bonsai-core/src/main/scala/com/stripe/bonsai/FullBinaryTree.scala
@@ -12,38 +12,43 @@ class FullBinaryTree[A, B](
   val branchLabels: Vec[A],
   val leafLabels: Vec[B]
 ) { tree =>
-  private def mkNodeRef(bitsetIndex: Int): NodeRef =
-    new NodeRef(bitset.rank(bitsetIndex) - 1)
 
-  def root: Option[NodeRef] =
-    if (bitset(0)) Some(mkNodeRef(0))
-    else None
+  private def mkNodeRef(bitsetIndex: Int): NodeRef = {
+    val index = bitset.rank(bitsetIndex) - 1
+    if (tree.leaf(index)) new LeafRef(index) else new BranchRef(index)
+  }
 
-  def isEmpty: Boolean =
-    root.isEmpty
+  def root: Option[NodeRef] = if (bitset(0)) Some(mkNodeRef(0)) else None
 
-  final class NodeRef private[FullBinaryTree] (index: Int) {
+  def isEmpty: Boolean = bitset(0)
+
+  sealed abstract class NodeRef {
+    def fold[R](f: (NodeRef, NodeRef, A) => R, g: B => R): R
+  }
+
+  final class LeafRef private[FullBinaryTree] (index: Int) extends NodeRef {
+    def label: B = leafLabels(bitset.rank(index) - 1)
+    def fold[R](f: (NodeRef, NodeRef, A) => R, g: B => R): R = g(label)
+  }
+
+  final class BranchRef private[FullBinaryTree] (index: Int) extends NodeRef {
+    def label: A = branchLabels(index - bitset.rank(index))
     def leftChild: NodeRef = tree.mkNodeRef(2 * index + 1)
     def rightChild: NodeRef = tree.mkNodeRef(2 * index + 2)
-    def isLeaf: Boolean = tree.leaf(index)
-    def branchLabel: A = branchLabels(index - bitset.rank(index))
-    def leafLabel: B = leafLabels(bitset.rank(index) - 1)
+    def fold[R](f: (NodeRef, NodeRef, A) => R, g: B => R): R = f(leftChild, rightChild, label)
   }
 }
 
 object FullBinaryTree {
-  implicit def BonsaiFullBinaryTreeOps[A, B]: FullBinaryTreeOps[FullBinaryTree[A, B]] =
-    new FullBinaryTreeOps[FullBinaryTree[A, B]] {
+  implicit def BonsaiFullBinaryTreeOps[A, B]: FullBinaryTreeOps[FullBinaryTree[A, B], A, B] =
+    new FullBinaryTreeOps[FullBinaryTree[A, B], A, B] {
       type Node = FullBinaryTree[A, B]#NodeRef
-      type BranchLabel = A
-      type LeafLabel = B
 
-      def root(t: FullBinaryTree[A, B]): Option[Node] = t.root
-      def isLeaf(node: Node): Boolean = node.isLeaf
-      def branchLabel(node: Node): BranchLabel = node.branchLabel
-      def leafLabel(node: Node): LeafLabel = node.leafLabel
-      def leftChild(node: Node): Node = node.leftChild
-      def rightChild(node: Node): Node = node.rightChild
+      def root(t: FullBinaryTree[A, B]): Option[Node] =
+        t.root
+
+      def foldNode[X](node: Node)(f: (Node, Node, A) => X, g: B => X): X =
+        node.fold(f, g)
     }
 
   /**
@@ -59,14 +64,13 @@ object FullBinaryTree {
    *
    * @param tree the tree whose structure we are copying
    */
-  def apply[T](tree: T)(implicit ev: FullBinaryTreeOps.WithLayout[T]): FullBinaryTree[ev.treeOps.BranchLabel, ev.treeOps.LeafLabel] = {
+  def apply[T, B, L](tree: T)(implicit ev: FullBinaryTreeOps[T, B, L]): FullBinaryTree[B, L] = {
     import ev._
-    import treeOps._
 
     val bitsBldr = Bitset.newBuilder
     val leafBldr = Bitset.newBuilder
-    val branchLabelBldr = Layout[BranchLabel].newBuilder
-    val leafLabelBldr = Layout[LeafLabel].newBuilder
+    val branchLabelBldr = Layout[B].newBuilder
+    val leafLabelBldr = Layout[L].newBuilder
 
     def build(nodes: Queue[Option[Node]]): Unit =
       if (nodes.nonEmpty) {
@@ -76,15 +80,16 @@ object FullBinaryTree {
             build(rest)
           case (Some(node), rest) =>
             bitsBldr += true
-            if (treeOps.isLeaf(node)) {
-              leafBldr += true
-              leafLabelBldr += treeOps.leafLabel(node)
-              build(rest.enqueue(None).enqueue(None))
-            } else {
+            val (ol, or) = foldNode(node)({ (lc, rc, bl) =>
               leafBldr += false
-              branchLabelBldr += treeOps.branchLabel(node)
-              build(rest.enqueue(Some(treeOps.leftChild(node))).enqueue(Some(treeOps.rightChild(node))))
-            }
+              branchLabelBldr += bl
+              (Some(lc), Some(rc))
+            }, { ll =>
+              leafBldr += true
+              leafLabelBldr += ll
+              (None, None)
+            })
+            build(rest.enqueue(ol).enqueue(or))
         }
       }
 

--- a/bonsai-core/src/main/scala/com/stripe/bonsai/FullBinaryTreeOps.scala
+++ b/bonsai-core/src/main/scala/com/stripe/bonsai/FullBinaryTreeOps.scala
@@ -1,62 +1,18 @@
 package com.stripe.bonsai
 
-trait FullBinaryTreeOps[T] extends TreeOps[T] {
-  type LeafLabel
-  type BranchLabel
-  type Label = Either[BranchLabel, LeafLabel]
+trait FullBinaryTreeOps[T, BL, LL] extends TreeOps[T, Either[BL, LL]] {
 
-  def isLeaf(node: Node): Boolean
+  type Label = Either[BL, LL]
 
-  def isBranch(node: Node): Boolean = !isLeaf(node)
+  def foldNode[A](node: Node)(f: (Node, Node, BL) => A, g: LL => A): A
 
-  def branchLabel(node: Node): BranchLabel
-
-  def leafLabel(node: Node): LeafLabel
-
-  // These 2 assume node is not a leaf
-
-  def leftChild(node: Node): Node
-
-  def rightChild(node: Node): Node
-
-  def label(node: Node): Either[BranchLabel, LeafLabel] =
-    if (isLeaf(node)) Right(leafLabel(node)) else Left(branchLabel(node))
-
-  // We could implement everything in terms of this instead, but I suspect
-  // we'd just end up constantly overriding this for perf :\
-  def foldLabel[A](node: Node)(f: BranchLabel => A, g: LeafLabel => A): A =
-    if (isLeaf(node)) g(leafLabel(node)) else f(branchLabel(node))
+  def label(node: Node): Either[BL, LL] =
+    foldNode(node)({ case (_, _, bl) => Left(bl) }, ll => Right(ll))
 
   def children(node: Node): Iterable[Node] =
-    if (isLeaf(node)) Nil else leftChild(node) :: rightChild(node) :: Nil
+    foldNode(node)({ case (lc, rc, _) => lc :: rc :: Nil }, _ => Nil)
 }
 
 object FullBinaryTreeOps {
-
-  final def apply[T](implicit ops: FullBinaryTreeOps[T]): FullBinaryTreeOps[T] = ops
-
-  /**
-   * A type alias for `TreeOps` that let's you use the `Node` and `Label` types
-   * with Scala's type inference / implicit lookup. You normally shouldn't need
-   * this, but is invaluable when you do.
-   */
-  type Aux[T, A, B] = FullBinaryTreeOps[T] {
-    type BranchLabel = A
-    type LeafLabel = B
-  }
-
-  trait WithLayout[T] {
-    implicit val treeOps: FullBinaryTreeOps[T]
-    implicit val branchLayout: Layout[treeOps.BranchLabel]
-    implicit val leafLayout: Layout[treeOps.LeafLabel]
-  }
-
-  object WithLayout {
-    implicit def mkWithLayout[T, A, B](implicit ops: Aux[T, A, B], la: Layout[A], lb: Layout[B]): WithLayout[T] =
-      new WithLayout[T] {
-        val treeOps = ops
-        val branchLayout = la
-        val leafLayout = lb
-      }
-  }
+  final def apply[T, BL, LL](implicit ops: FullBinaryTreeOps[T, BL, LL]): FullBinaryTreeOps[T, BL, LL] = ops
 }

--- a/bonsai-core/src/main/scala/com/stripe/bonsai/Layout.scala
+++ b/bonsai-core/src/main/scala/com/stripe/bonsai/Layout.scala
@@ -18,15 +18,11 @@ trait Layout[A] {
   def optional: Layout[Option[A]] = Layout.optional(this)
 }
 
-trait LayoutLow1 {
-  implicit def denseVector[A]: Layout[A] = new DenseIndexedSeqLayout[Vector, A]
-}
-
-trait LayoutLow2 extends LayoutLow1 {
+trait LayoutLow {
   implicit def denseArray[A: ClassTag]: Layout[A] = new DenseArrayLayout[A]
 }
 
-object Layout extends LayoutLow2 {
+object Layout extends LayoutLow {
   def apply[A](implicit layout: Layout[A]): Layout[A] = layout
 
   implicit def optional[A](implicit layout: Layout[A]): Layout[Option[A]] = new OptionalLayout(layout)

--- a/bonsai-core/src/main/scala/com/stripe/bonsai/Tree.scala
+++ b/bonsai-core/src/main/scala/com/stripe/bonsai/Tree.scala
@@ -72,7 +72,7 @@ object Tree {
    *
    * @param tree the tree whose structure we are copying
    */
-  def apply[T, L](tree: T)(implicit ev: TreeOps[T, L]): Tree[L] = {
+  def apply[T, L](tree: T)(implicit ev: TreeOps[T, L], ll: Layout[L]): Tree[L] = {
     import ev._
 
     // We accept k-ary trees, but actually need binary trees for the succinct
@@ -136,7 +136,7 @@ object Tree {
     }
 
     val bitsBldr = Bitset.newBuilder
-    val labelBldr = Layout[L].newBuilder
+    val labelBldr = ll.newBuilder
 
     // We build the datastructure in this loop. We traverse the transformed
     // tree in level-order (breadth-first search). Each internal node is marked

--- a/bonsai-core/src/main/scala/com/stripe/bonsai/Tree.scala
+++ b/bonsai-core/src/main/scala/com/stripe/bonsai/Tree.scala
@@ -50,14 +50,13 @@ class Tree[A](val bitset: Bitset, val labels: Vec[A]) {
 }
 
 object Tree {
-  implicit def BonsaiTreeOps[A]: TreeOps[Tree[A]] =
-    new TreeOps[Tree[A]] {
+  implicit def BonsaiTreeOps[A]: TreeOps[Tree[A], A] =
+    new TreeOps[Tree[A], A] {
       type Node = NodeRef[A]
-      type Label = A
 
       def root(t: Tree[A]): Option[Node] = t.root
       def children(node: Node): Iterable[Node] = node
-      def label(node: Node): Label = node.label
+      def label(node: Node): A = node.label
     }
 
   /**
@@ -73,9 +72,8 @@ object Tree {
    *
    * @param tree the tree whose structure we are copying
    */
-  def apply[T](tree: T)(implicit ev: TreeOps.WithLayout[T]): Tree[ev.treeOps.Label] = {
+  def apply[T, L](tree: T)(implicit ev: TreeOps[T, L]): Tree[L] = {
     import ev._
-    import treeOps._
 
     // We accept k-ary trees, but actually need binary trees for the succinct
     // data structure. So, we use the first-child/sibling representation to
@@ -138,7 +136,7 @@ object Tree {
     }
 
     val bitsBldr = Bitset.newBuilder
-    val labelBldr = Layout[Label].newBuilder
+    val labelBldr = Layout[L].newBuilder
 
     // We build the datastructure in this loop. We traverse the transformed
     // tree in level-order (breadth-first search). Each internal node is marked

--- a/bonsai-core/src/main/scala/com/stripe/bonsai/TreeOps.scala
+++ b/bonsai-core/src/main/scala/com/stripe/bonsai/TreeOps.scala
@@ -33,19 +33,15 @@ package com.stripe.bonsai
  * }
  * }}}
  */
-trait TreeOps[T] { ops =>
-  type WithLabel[L] = TreeOps[T] { type Label = L }
+trait TreeOps[Tree, Label] { ops =>
 
   /** The type of the nodes in the tree. */
   type Node
 
-  /** The type of the label attached to each node. */
-  type Label
-
   /**
    * Returns the root node of the tree.
    */
-  def root(t: T): Option[Node]
+  def root(t: Tree): Option[Node]
 
   /**
    * Returns all the direct children of the given node. The order may or may
@@ -61,12 +57,12 @@ trait TreeOps[T] { ops =>
   def fold[A](f: (Label, Iterable[A]) => A)(node: Node): A =
     f(label(node), children(node).map(fold(f)))
 
-  implicit class TreeTreeOps(tree: T) {
+  implicit class OpsForTree(tree: Tree) {
     def root: Option[Node] = ops.root(tree)
     def fold[A](f: (Label, Iterable[A]) => A): Option[A] = root.map(ops.fold(f))
   }
 
-  implicit class TreeNodeOps(node: Node) {
+  implicit class OpsForNode(node: Node) {
     def children: Iterable[Node] = ops.children(node)
     def label: Label = ops.label(node)
     def fold[A](f: (Label, Iterable[A]) => A): A = ops.fold(f)(node)
@@ -74,27 +70,5 @@ trait TreeOps[T] { ops =>
 }
 
 object TreeOps {
-  final def apply[T](implicit ops: TreeOps[T]) = ops
-
-  /**
-   * A type alias for `TreeOps` that let's you use the `Node` and `Label` types
-   * with Scala's type inference / implicit lookup. You normally shouldn't need
-   * this, but is invaluable when you do.
-   */
-  type Aux[T, L] = TreeOps[T] {
-    type Label = L
-  }
-
-  trait WithLayout[T] {
-    implicit val treeOps: TreeOps[T]
-    implicit val layout: Layout[treeOps.Label]
-  }
-
-  object WithLayout {
-    implicit def mkWithLayout[T, D](implicit ops: Aux[T, D], lt: Layout[D]): WithLayout[T] =
-      new WithLayout[T] {
-        val treeOps = ops
-        val layout = lt
-      }
-  }
+  final def apply[Tree, Label](implicit ops: TreeOps[Tree, Label]) = ops
 }

--- a/bonsai-core/src/test/scala/com/stripe/bonsai/GenericTree.scala
+++ b/bonsai-core/src/test/scala/com/stripe/bonsai/GenericTree.scala
@@ -12,13 +12,13 @@ object GenericTree {
   def leaf[A](label: A): GenericTree[A] =
     GenericTree(label, Nil)
 
-  implicit def GenericTreeOps[A] = new TreeOps[GenericTree[A]] {
-    type Node = GenericTree[A]
-    type Label = A
-    def root(t: GenericTree[A]): Option[Node] = Some(t)
-    def children(node: Node): List[Node] = node.children
-    def label(node: Node): Label = node.label
-  }
+  implicit def GenericTreeOps[A]: TreeOps[GenericTree[A], A] =
+    new TreeOps[GenericTree[A], A] {
+      type Node = GenericTree[A]
+      def root(t: GenericTree[A]): Option[Node] = Some(t)
+      def children(node: Node): List[Node] = node.children
+      def label(node: Node): A = node.label
+    }
 
   def fromTree[A](tree: Tree[A]): Option[GenericTree[A]] = {
     def mkTree(node: Tree.NodeRef[A]): GenericTree[A] =


### PR DESCRIPTION
This commit changes TreeOps (and FullBinaryTreeOps) to
expose the labels as a type parameter. While this is
sometimes unnecessary for Bonsai itself, it makes
working with Bonsai in situations where the labels
are important much easier.

It also changes the core abstraction to use .foldNode
instead of .isLeaf, .isNode, .children, and casting.
This ends up being a lot nicer to work with, especially
for binary trees where leaves and branches have different
labels.

(Since trees are never that deep, we don't have to
worry about the non-tail recursion that .foldNode
introduces.)

Review by @tixxit.