### PR TITLE
Fix off-by-1 error in DenseArrayLayout dict encoding.

### DIFF
--- a/bonsai-core/src/main/scala/com/stripe/bonsai/layout/DenseLayout.scala
+++ b/bonsai-core/src/main/scala/com/stripe/bonsai/layout/DenseLayout.scala
@@ -35,7 +35,7 @@ sealed abstract class DenseArrayLayout[A: ClassTag](
 
       case DenseArrayLayout.ByteDictionaryEncoding =>
         val dictLen = in.readInt()
-        require(dictLen <= 255)
+        require(dictLen <= 256)
         val dict: Array[A] = new Array[A](dictLen)
         readArray(in, dict)
         val encoding: Array[Byte] = new Array[Byte](in.readInt())


### PR DESCRIPTION
We can encode up to 256 unique values using the byte dictionary encoding, but on read, we were requiring at most 255. So, when we had *exactly* 256 unique values, it would fail on read. It's possible scalacheck may have caught this eventually, but I'm a little sad it didn't :( Anyways, there is now a unit test too.