### PR TITLE
FullBinaryTreeOps methods for collecting labels

### DIFF
--- a/bonsai-core/src/main/scala/com/stripe/bonsai/FullBinaryTreeOps.scala
+++ b/bonsai-core/src/main/scala/com/stripe/bonsai/FullBinaryTreeOps.scala
@@ -21,6 +21,17 @@ trait FullBinaryTreeOps[T, BL, LL] extends TreeOps[T, Either[BL, LL]] {
 
   def children(node: Node): Iterable[Node] =
     foldNode(node)({ case (lc, rc, _) => lc :: rc :: Nil }, _ => Nil)
+
+  def collectLabelsF[A](node: Node, f: Label => A): Set[A] =
+    foldNode(node)(
+      { case (lc, rc, label) => Set(f(Left(label))) | collectLabelsF(lc, f) | collectLabelsF(rc, f) },
+        ll => Set(f(Right(ll))))
+
+  def collectLeafLabelsF[A](node: Node, f: LL => A): Set[A] =
+    foldNode(node)({case (lc, rc, _) => collectLeafLabelsF(lc, f) | collectLeafLabelsF(rc, f)}, ll => Set(f(ll)))
+
+  def collectLabels(node: Node): Set[Label] = collectLabelsF(node, identity)
+  def collectLeafLabels(node: Node): Set[LL] = collectLeafLabelsF(node, identity)
 }
 
 object FullBinaryTreeOps {

--- a/bonsai-core/src/test/scala/com/stripe/bonsai/FullBinaryTreeSpec.scala
+++ b/bonsai-core/src/test/scala/com/stripe/bonsai/FullBinaryTreeSpec.scala
@@ -93,4 +93,24 @@ class FullBinaryTreeSpec extends WordSpec with Matchers with Checkers with Prope
       }
     }
   }
+
+  "FullBinaryTreeOps" should {
+    "collect leaf labels" in {
+      val genTree = GenericBinTree.branch(2, GenericBinTree.leaf(1), GenericBinTree.leaf(3))
+      val bt1 = FullBinaryTree(genTree)
+      ops.collectLeafLabels(ops.root(bt1).get) shouldBe Set(1, 3)
+    }
+
+    "stream all labels" in {
+      import GenericBinTree._
+      val genTree = branch(0, branch(2, leaf(1), leaf(3)), branch(6, leaf(5), leaf(0)))
+      val bt1 = FullBinaryTree(genTree)
+      val expected = List(1, 2, 3, 0, 5, 6, 0)
+      val unpackLabel: ops.Label => Int = _ match {
+        case Left(i)=> i
+        case Right(i) => i
+      }
+      ops.collectLabelsF(ops.root(bt1).get, unpackLabel) shouldBe expected.toSet
+    }
+  }
 }


### PR DESCRIPTION
When writing tests on binary trees, I've occasionally wanted to be able to obtain a list of the trees' keys, to aid in constructing sample data and models.

This PR adds four methods for collecting labels from full binary trees:

- `collectLabels`
- `collectLabelsF`
- `collectLeafLabels`
- `collectLeafLabelsF`

These methods return sets, as we shouldn't have any opinion on the ordering of labels in `FullBinaryTreeOps` (ordered traversals should be handled in Brushfire's `TreeTraversal`s[0]).

cc @erik-stripe @kelley-stripe @oscar-stripe @rob-stripe @thomas-stripe 

[0] https://github.com/stripe/brushfire/blob/master/brushfire-tree/src/main/scala/com/stripe/brushfire/TreeTraversal.scala