### PR TITLE
Add Layout instances for collections

### DIFF
--- a/bonsai-core/src/main/scala/com/stripe/bonsai/Layout.scala
+++ b/bonsai-core/src/main/scala/com/stripe/bonsai/Layout.scala
@@ -43,6 +43,12 @@ object Layout {
   implicit def denseStringLayout: Layout[String] = DenseStringLayout
 
   implicit def optional[A](implicit layout: Layout[A]): Layout[Option[A]] = new OptionalLayout(layout)
+  implicit def setLayout[A](implicit layout: Layout[A], offsetsLayout: Layout[Int]): Layout[Set[A]] =
+    new ColLayout[A, Set[A]](layout, offsetsLayout)
+  implicit def mapLayout[K, V](implicit layout: Layout[(K, V)], offsetsLayout: Layout[Int]): Layout[Map[K, V]] =
+    new ColLayout[(K, V), Map[K, V]](layout, offsetsLayout)
+  implicit def vectorLayout[A](implicit layout: Layout[A], offsetsLayout: Layout[Int]): Layout[Vector[A]] =
+    new ColLayout[A, Vector[A]](layout, offsetsLayout)
 
   /**
    * Returns a data store that can store either A or B and requires only

--- a/bonsai-core/src/main/scala/com/stripe/bonsai/layout/ColLayout.scala
+++ b/bonsai-core/src/main/scala/com/stripe/bonsai/layout/ColLayout.scala
@@ -1,0 +1,47 @@
+package com.stripe.bonsai
+package layout
+
+import java.io.{ DataOutput, DataInput }
+import scala.collection.IterableLike
+import scala.collection.generic.{ CanBuildFrom, IsTraversableLike }
+
+case class ColLayout[A, Repr <: IterableLike[A, Repr]](
+  layout: Layout[A],
+  offsetsLayout: Layout[Int]
+)(implicit
+  cbf: CanBuildFrom[Nothing, A, Repr]
+) extends Layout[Repr] {
+  def newBuilder: VecBuilder[Repr] =
+    new DenseBuilder(Vector.newBuilder[Repr], Vec.fromVector)
+
+  def isSafeToCast(vec: Vec[_]): Boolean = false
+
+  def write(vec: Vec[Repr], out: DataOutput): Unit = {
+    out.writeByte(ColLayout.OffsetEncoding)
+    val offsetsBldr = offsetsLayout.newBuilder
+    val bldr = layout.newBuilder
+    var offset = 0
+    vec.foreach { values =>
+      offsetsBldr += offset
+      offset += values.size
+      bldr ++= values
+    }
+    offsetsLayout.write(offsetsBldr.result(), out)
+    layout.write(bldr.result(), out)
+  }
+
+  def read(in: DataInput): Vec[Repr] =
+    in.readByte() match {
+      case ColLayout.OffsetEncoding =>
+        val offsets = offsetsLayout.read(in)
+        val values = layout.read(in)
+        ColVec(offsets, values)(cbf)
+
+      case e =>
+        throw new java.io.IOException(s"unsupported encoding for ColLayout: $e")
+    }
+}
+
+object ColLayout {
+  final val OffsetEncoding = 1.toByte
+}

--- a/bonsai-core/src/test/scala/com/stripe/bonsai/LayoutSpec.scala
+++ b/bonsai-core/src/test/scala/com/stripe/bonsai/LayoutSpec.scala
@@ -111,6 +111,8 @@ class LayoutSpec extends WordSpec with Matchers with Checkers {
   layoutCheck[Set[Long]]("Set[Long]")
   layoutCheck[Map[String, Long]]("Map[String, Long]")
   layoutCheck[Vector[Long]]("Vector[Long]")
+  layoutCheck[Vector[Vector[Vector[String]]]]("Vector[Vector[Vector[String]]]")
+  layoutCheck[Map[Option[String], (Int, Set[Long])]]("Map[Option[String], (Int, Set[Long])]")
 
   case class Point(x: Double, y: Double)
   object Point extends {

--- a/bonsai-core/src/test/scala/com/stripe/bonsai/LayoutSpec.scala
+++ b/bonsai-core/src/test/scala/com/stripe/bonsai/LayoutSpec.scala
@@ -108,6 +108,9 @@ class LayoutSpec extends WordSpec with Matchers with Checkers {
   layoutCheck[Either[String, Long]]("Either[String, Long]")
   layoutCheck[(Short, String)]("(Short, String)")
   layoutCheck[(Short, Int, Double)]("(Short, Int, Double)")
+  layoutCheck[Set[Long]]("Set[Long]")
+  layoutCheck[Map[String, Long]]("Map[String, Long]")
+  layoutCheck[Vector[Long]]("Vector[Long]")
 
   case class Point(x: Double, y: Double)
   object Point extends {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.15


### PR DESCRIPTION
Adapted from a specialized `Set` implementation by @thomas-stripe.

General question: there are three approaches I can imagine using here to provide `Layout` instances for the desired collection types (i.e. `Set`, `Map`, and `Vector`):

1. Provide separate `Layout` implementations for each of these types.
2. Use a single generic implementation but only provide instances for these specific types.
3. Use a single generic implementation and provide instances for all applicable types.

I've chosen the middle route—there's a shared implementation but to keep things simple we don't provide implicit instances for e.g. `Seq`, `List`, etc. If it's too much `CanBuildFrom` we could easily switch to the first approach, though.

Three minor points:
1. I've created a `Vec.fromVector` method since this seemed potentially more generally useful.
2. I've followed the naming you see in some places in `scala.collection` with `Col`, but I'm happy to change it.
3. I'm assuming we don't need to test instances for more complex types, but I can add more tests if anyone would like.