### PR TITLE
Add label collection methods, clean up API a bit

### DIFF
--- a/bonsai-core/src/main/scala/com/stripe/bonsai/FullBinaryTreeOps.scala
+++ b/bonsai-core/src/main/scala/com/stripe/bonsai/FullBinaryTreeOps.scala
@@ -19,6 +19,17 @@ trait FullBinaryTreeOps[T, BL, LL] extends TreeOps[T, Either[BL, LL]] {
 
   def children(node: Node): Iterable[Node] =
     foldNode(node)({ case (lc, rc, _) => lc :: rc :: Nil }, _ => Nil)
+
+  def collectLabelsF[A](node: Node, f: Label => A): Set[A] =
+    foldNode(node)(
+      { case (lc, rc, label) => Set(f(Left(label))) | collectLabelsF(lc, f) | collectLabelsF(rc, f) },
+        ll => Set(f(Right(ll))))
+
+  def collectLeafLabelsF[A](node: Node, f: LL => A): Set[A] =
+    foldNode(node)({case (lc, rc, _) => collectLeafLabelsF(lc, f) | collectLeafLabelsF(rc, f)}, ll => Set(f(ll)))
+
+  def collectLabels(node: Node): Set[Label] = collectLabelsF(node, identity)
+  def collectLeafLabels(node: Node): Set[LL] = collectLeafLabelsF(node, identity)
 }
 
 object FullBinaryTreeOps {

--- a/bonsai-core/src/main/scala/com/stripe/bonsai/TreeOps.scala
+++ b/bonsai-core/src/main/scala/com/stripe/bonsai/TreeOps.scala
@@ -66,6 +66,11 @@ trait TreeOps[Tree, Label] { ops =>
   def reduce[A](tree: Tree)(f: (Label, Iterable[A]) => A): Option[A] =
     root(tree).map(n => reduce(n)(f))
 
+  def collectLabelsF[A](node: Node)(f: Label => A): Set[A] =
+    reduce[Set[A]](node)((lbl, cs) => cs.foldLeft(Set(f(lbl)))(_ ++ _))
+
+  def collectLabels(node: Node): Set[Label] = collectLabelsF(node)(identity)
+
   implicit class OpsForTree(tree: Tree) {
     def root: Option[Node] = ops.root(tree)
     def reduce[A](f: (Label, Iterable[A]) => A): Option[A] = root.map(ops.reduce(_)(f))

--- a/bonsai-core/src/test/scala/com/stripe/bonsai/FullBinaryTreeSpec.scala
+++ b/bonsai-core/src/test/scala/com/stripe/bonsai/FullBinaryTreeSpec.scala
@@ -17,13 +17,13 @@ class FullBinaryTreeSpec extends WordSpec with Matchers with Checkers with Prope
     }
 
   def sumNode(n: ops.Node): Long =
-    ops.foldNode(n)((lc, rc, n) => n + sumNode(lc) + sumNode(rc), n => n)
+    ops.foldNode(n)((n, lc, rc) => n + sumNode(lc) + sumNode(rc), n => n)
 
   def nodeElems(n: ops.Node): Set[Int] =
-    ops.foldNode(n)((lc, rc, n) => Set(n) | nodeElems(lc) | nodeElems(rc), Set(_))
+    ops.foldNode(n)((n, lc, rc) => Set(n) | nodeElems(lc) | nodeElems(rc), Set(_))
 
   def minNode(n: ops.Node): Int =
-    ops.foldNode(n)((lc, rc, n) => (n min (minNode(lc) min minNode(rc))), n => n)
+    ops.foldNode(n)((n, lc, rc) => (n min (minNode(lc) min minNode(rc))), n => n)
 
   "write" should {
     "round-trip through read" in {
@@ -106,11 +106,7 @@ class FullBinaryTreeSpec extends WordSpec with Matchers with Checkers with Prope
       val genTree = branch(0, branch(2, leaf(1), leaf(3)), branch(6, leaf(5), leaf(0)))
       val bt1 = FullBinaryTree(genTree)
       val expected = List(1, 2, 3, 0, 5, 6, 0)
-      val unpackLabel: ops.Label => Int = _ match {
-        case Left(i)=> i
-        case Right(i) => i
-      }
-      ops.collectLabelsF(ops.root(bt1).get, unpackLabel) shouldBe expected.toSet
+      ops.collectLabelsF(ops.root(bt1).get)(_.merge) shouldBe expected.toSet
     }
   }
 }

--- a/bonsai-core/src/test/scala/com/stripe/bonsai/FullBinaryTreeSpec.scala
+++ b/bonsai-core/src/test/scala/com/stripe/bonsai/FullBinaryTreeSpec.scala
@@ -93,4 +93,24 @@ class FullBinaryTreeSpec extends WordSpec with Matchers with Checkers with Prope
       }
     }
   }
+
+  "FullBinaryTreeOps" should {
+    "collect leaf labels" in {
+      val genTree = GenericBinTree.branch(2, GenericBinTree.leaf(1), GenericBinTree.leaf(3))
+      val bt1 = FullBinaryTree(genTree)
+      ops.collectLeafLabels(ops.root(bt1).get) shouldBe Set(1, 3)
+    }
+
+    "stream all labels" in {
+      import GenericBinTree._
+      val genTree = branch(0, branch(2, leaf(1), leaf(3)), branch(6, leaf(5), leaf(0)))
+      val bt1 = FullBinaryTree(genTree)
+      val expected = List(1, 2, 3, 0, 5, 6, 0)
+      val unpackLabel: ops.Label => Int = _ match {
+        case Left(i)=> i
+        case Right(i) => i
+      }
+      ops.collectLabelsF(ops.root(bt1).get, unpackLabel) shouldBe expected.toSet
+    }
+  }
 }

--- a/bonsai-core/src/test/scala/com/stripe/bonsai/GenericTree.scala
+++ b/bonsai-core/src/test/scala/com/stripe/bonsai/GenericTree.scala
@@ -57,16 +57,16 @@ object GenericBinTree {
       def root(t: GenericBinTree[A]): Option[Node] =
         Some(t)
 
-      def foldNode[X](node: Node)(f: (Node, Node, A) => X, g: A => X): X =
+      def foldNode[X](node: Node)(f: (A, Node, Node) => X, g: A => X): X =
         node.children match {
-          case Some((lc, rc)) => f(lc, rc, node.label)
+          case Some((lc, rc)) => f(node.label, lc, rc)
           case None => g(node.label)
         }
     }
 
   def fromTree[A](tree: FullBinaryTree[A, A]): Option[GenericBinTree[A]] = {
     def construct(n: tree.NodeRef): GenericBinTree[A] =
-      n.fold({ (lc, rc, a) =>
+      n.fold({ (a, lc, rc) =>
         GenericBinTree.branch(a, construct(lc), construct(rc))
       }, GenericBinTree.leaf)
     tree.root.map(construct)


### PR DESCRIPTION
This PR rebases @jhoon-stripe's additions in #15 and addresses @thomas-stripe's comments, and also cleans up a few things (starting along the lines of Tom's suggestions).

There's no rush on this, and it includes several (superficial) breaking changes, so if people don't think it's worthwhile I'm happy to scrap it—I just wanted to open the PR before I forget.

The main breaking changes have to do with consistency of the `fold*` and `reduce*` signatures. Currently there's some variation in whether the label or children come first in functions that require both—e.g. in `NodeRef#reduce`, `TreeOps#fold`, etc., the label comes first, but in `NodeRef#fold` and `FullBinaryTreeOps#foldNode` the children come first:

```scala
def reduce[X](f: (A, X, X) => X)(g: B => X): X              // FullBinaryTree#NodeRef
def fold[A](node: Node)(f: (Label, Iterable[Node]) => A): A // TreeOps

def fold[R](f: (NodeRef, NodeRef, A) => R, g: B => R): R             // FullBinaryTree#NodeRef
def foldNode[A](node: Node)(f: (Node, Node, BL) => A, g: LL => A): A // FullBinaryTreeOps
```

I've changed all signatures across the board to put the label first, since that seemed to be the more common case.

There's also some variation in whether folds or reductions that take two function arguments give each its own parameter list (`reduce` above) or combine them in a single list (all the others). In the case of two function arguments I don't think there's a strong case that one approach or the other is more idiomatic, and putting them together is slightly nicer for type inference (and I think more common here), so I've done that throughout.

Another breaking change is related to @thomas-stripe's comment [here](https://github.com/stripe/bonsai/pull/15#discussion_r87839671) suggesting a new `reduceFullBinaryTree` method. Since `reduceNode` is already specific to `FullBinaryTreeOps`, there's not really any reason it needs the `Iterable` in its signature, so I've rewritten it to be more or less Tom's suggested `reduceFullBinaryTree` (but following my new conventions above).

@thomas-stripe also [notes](https://github.com/stripe/bonsai/pull/15#discussion_r87838588) that `collectLabels` could go on `TreeOps`, and this is also the case for `collectLabelsF`, so I've put both of them there.

Unfortunately we can't make the breaking changes with a deprecation cycle, since a lot of the signatures are the same after erasure, but I'd be happy to take responsibility for writing up release notes and adding the commas / making the minor rearrangements that our code using bonsai will need.